### PR TITLE
Fix dpdk submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dpdk"]
 	path = dpdk
-	url = ../dpdk
+	url = https://github.com/scylladb/dpdk


### PR DESCRIPTION
Since we haven't forked dpdk, we need to update the submodule URL as `.gitmodules` was using a relative path.